### PR TITLE
Chart width and rendering fix

### DIFF
--- a/content/scripts/SCFSD.js
+++ b/content/scripts/SCFSD.js
@@ -45,6 +45,10 @@ SCFSD.prototype.DrawShips = function () {
     if (shipMarginBottom % 1 === 0) {
         _self.cssOverrides.push(".Ship{margin-bottom:" + shipMarginBottom + "px;}");
     }
+    var imageWidth = parseInt($("#ImageWidth").val(), 10);
+    if (imageWidth % 1 === 0) {
+        _self.cssOverrides.push("#ShipOutput{width:" + imageWidth + "px;}");
+    }
 
     _self.cssOverrides.push("#ShipOutput{background-color:" + $("#BackgroundColor").val() + ";}");
     _self.cssOverrides.push("#ShipOutput{color:" + $("#FontColor").val() + ";}");

--- a/index.html
+++ b/index.html
@@ -102,6 +102,8 @@
             <dd><input type="number" id="LogoWidth" /></dd>
             <dt>Logo Height</dt>
             <dd><input type="number" id="LogoHeight" /></dd>
+            <dt>Chart Width</dt>
+            <dd><input type="number" id="ImageWidth" /></dd>
             <dt>Ship Margin (Right)</dt>
             <dd><input type="number" id="ShipMarginRight" /></dd>
             <dt>Ship Margin (Bottom)</dt>

--- a/index.html
+++ b/index.html
@@ -156,7 +156,7 @@
         </dl>
         </fieldset>
         <div class="clear">
-            <a href="#Top">
+            <a href="#">
                 <input type="button" value="Draw my Faction!" id="btnDrawFaction" /> <input type="button" onclick="shipDrawer.ClearShips();" value="Clear" />
             </a>
             <a id="DownloadImageLink" download="FactionShips.png" href="#">Download as Image</a>


### PR DESCRIPTION
- Added a chart width option to allow setting a custom chart width (feel free to rename this if you want)
- Fixed the rendered image ending up with a "jump" at the top (I thought this was just a Firefox issue, but turns out it affects Chrome as well)